### PR TITLE
Fix loading of `vite.config.ts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ yarn prepare
 yarn watch
 ```
 
-You can add additional buildable config in `vite.config.ts` but in my opinion I made everything which I can. After that you can start writing your scripts in `src` directory, and it will automatically will be built into kubejs/*_scripts directories depends on file. You can find more information about `KubeJS` mod in [here](https://kubejs.latvian.dev/).
+You can add additional buildable config in `vite.config.js` but in my opinion I made everything which I can. After that you can start writing your scripts in `src` directory, and it will automatically will be built into kubejs/*_scripts directories depends on file. You can find more information about `KubeJS` mod in [here](https://kubejs.latvian.dev/).
 
 # File Structure
 Here have 3 entry points for `vite` build.

--- a/kube-js/plugin/package.json
+++ b/kube-js/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubejs/plugin",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A KubeJS plugin",
   "repository": {
     "type": "git",

--- a/kube-js/plugin/src/core/program.ts
+++ b/kube-js/plugin/src/core/program.ts
@@ -59,7 +59,7 @@ export class Program<TCmdOptions extends string | number, TArgs> {
       if (problemIndex === -1) return;
 
       const fnStart = problemIndex - 1;
-      const fnEnd = problemIndex + 6;
+      const fnEnd = problemIndex + 7;
 
       // We know that we are not in a reflective environment, so we patch the function to simply return false
       const right = "return false;";

--- a/kube-js/plugin/src/core/program.ts
+++ b/kube-js/plugin/src/core/program.ts
@@ -57,15 +57,11 @@ export class Program<TCmdOptions extends string | number, TArgs> {
 
       // If not found, skip
       if (problemIndex === -1) return;
-
       const fnStart = problemIndex - 1;
-      const fnEnd = problemIndex + 7;
 
       // We know that we are not in a reflective environment, so we patch the function to simply return false
-      const right = "return false;";
+      lines.splice(fnStart, 8, "return false;");
 
-      // Replace the content
-      lines.splice(fnStart, fnEnd - fnStart, right);
       // Write the file
       await writeFile(file, lines.join("\n"));
     });

--- a/kube-js/plugin/src/core/program.ts
+++ b/kube-js/plugin/src/core/program.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readdir, writeFile, readFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
 import { UserConfig, UserConfigExport, build } from "vite";
@@ -30,11 +30,13 @@ export class Program<TCmdOptions extends string | number, TArgs> {
     public cmd: TCmdOptions,
     public options: TCmdOptions[],
     public args: TArgs
-  ) { }
+  ) {}
 
   async patch() {
     // Patch the output scripts due to rhino made the var scoped
-    const outputs = ["client", "server", "startup"].map(env => resolve(`kubejs/${env}_scripts/script.js`));
+    const outputs = ["client", "server", "startup"].map(env =>
+      resolve(`kubejs/${env}_scripts/script.js`)
+    );
 
     // Load the file and split the lines
     const promises = outputs.map(async file => {
@@ -53,7 +55,9 @@ export class Program<TCmdOptions extends string | number, TArgs> {
       // }
 
       // Locate !Boolean.prototype.valueOf.call(Reflect.construct(Boolean, [], function() {
-      const problemIndex = lines.findIndex(line => line.includes("valueOf.call(Reflect.construct(Boolean, [], function() {"));
+      const problemIndex = lines.findIndex(line =>
+        line.includes("valueOf.call(Reflect.construct(Boolean, [], function() {")
+      );
 
       // If not found, skip
       if (problemIndex === -1) return;
@@ -123,7 +127,7 @@ export class Program<TCmdOptions extends string | number, TArgs> {
         logLevel: "silent"
       };
 
-      const userDefinedConfigFile = resolve(process.cwd(), "vite.config.ts");
+      const userDefinedConfigFile = resolve(process.cwd(), "vite.config.js");
       if (existsSync(userDefinedConfigFile)) {
         const userDefinedConfig = (await import(userDefinedConfigFile)) as UserConfigExport;
         if (typeof userDefinedConfig === "function") {

--- a/kube-js/plugin/src/core/program.ts
+++ b/kube-js/plugin/src/core/program.ts
@@ -133,7 +133,9 @@ export class Program<TCmdOptions extends string | number, TArgs> {
         const userDefinedConfigUrl = this.isWindows()
           ? `file://${userDefinedConfigFile}`
           : userDefinedConfigFile;
-        const userDefinedConfig = (await import(userDefinedConfigUrl)) as UserConfigExport;
+        const { default: userDefinedConfig } = (await import(userDefinedConfigUrl)) as {
+          default: UserConfigExport;
+        };
         if (typeof userDefinedConfig === "function") {
           const result = await userDefinedConfig({
             command: "build",

--- a/kube-js/plugin/src/core/program.ts
+++ b/kube-js/plugin/src/core/program.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
+import _ from "lodash";
 import * as os from "os";
 import { UserConfig, UserConfigExport, build } from "vite";
 
@@ -143,7 +144,7 @@ export class Program<TCmdOptions extends string | number, TArgs> {
             isSsrBuild: false,
             mode: "production"
           });
-          Object.assign(baseConfig, result);
+          _.merge(baseConfig, result);
         }
       }
 

--- a/kube-js/plugin/src/core/program.ts
+++ b/kube-js/plugin/src/core/program.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
+import * as os from "os";
 import { UserConfig, UserConfigExport, build } from "vite";
 
 import babel from "@rollup/plugin-babel";
@@ -129,7 +130,10 @@ export class Program<TCmdOptions extends string | number, TArgs> {
 
       const userDefinedConfigFile = resolve(process.cwd(), "vite.config.js");
       if (existsSync(userDefinedConfigFile)) {
-        const userDefinedConfig = (await import(userDefinedConfigFile)) as UserConfigExport;
+        const userDefinedConfigUrl = this.isWindows()
+          ? `file://${userDefinedConfigFile}`
+          : userDefinedConfigFile;
+        const userDefinedConfig = (await import(userDefinedConfigUrl)) as UserConfigExport;
         if (typeof userDefinedConfig === "function") {
           const result = await userDefinedConfig({
             command: "build",
@@ -218,5 +222,10 @@ Hello dear KubeJS developer! Building project for you... State of parts:
       default:
         return state;
     }
+  }
+
+  private isWindows(): boolean {
+    // it will return 'win32' even on win64 systems
+    return os.platform() === "win32";
   }
 }


### PR DESCRIPTION
This *should* fix the issues outlined in #6, at least on Windows. I don't have easy access to any other systems to test on.

Important to note is that it will now look for `vite.config.js` instead of `vite.config.ts`. It might also be good to provide an example `vite.config.js` at some point, but that's outside of the scope of this PR.